### PR TITLE
Add python3-setuptools dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Install PiDi Spotify using git, best stick it in `/home/pi` so we're working fro
 cd /home/pi
 git clone https://github.com/pimoroni/pidi-spotify
 cd pidi-spotify
+sudo apt-get install python3-setuptools
 sudo python3 setup.py install
 ```
 


### PR DESCRIPTION
I was missing `python3-setuptools`. I had to install it before running the setup.